### PR TITLE
纠正 `负债累累` `经纶济世` 的拼音

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # ChangeLog
 
 
+## 未发布
+
+* 纠正 `负债累累` `经纶济世` 的拼音
+
+
 ## [0.7.0] (2018-05-27)
 
 * 新增 zdic_cibs.txt 和 zdic_cybs.txt (via [#13])

--- a/overwrite.txt
+++ b/overwrite.txt
@@ -69,3 +69,5 @@
 详情度理: xiáng qíng duó lǐ
 谦受益: qiān shòu yì
 禁脔: jìn luán
+经纶济世: jīng lún jì shì
+负债累累: fù zhài lěi lěi


### PR DESCRIPTION

* 纠正 `负债累累` `经纶济世` 的拼音 Fixes https://github.com/mozillazg/python-pinyin/issues/128